### PR TITLE
Fix links to v1 and v1.1 schemas on index page

### DIFF
--- a/udp/index.html
+++ b/udp/index.html
@@ -61,10 +61,10 @@
                 <a class="navbar-item" href="ucdm/relational-schema.html">
                   Relational schema
                 </a>
-                <a class="navbar-item" href="../ucdm/sis-loading-schema-v1.html">
+                <a class="navbar-item" href="ucdm/sis-loading-schema-v1.html">
                   SIS Loading Schema for UCDM (v1)
                 </a>
-                <a class="navbar-item" href="../ucdm/sis-loading-schema-v1p1.html">
+                <a class="navbar-item" href="ucdm/sis-loading-schema-v1p1.html">
                   SIS Loading Schema proposed changes (v1.1)
                 </a>
                 <a class="navbar-item" href="ucdm/canvas-to-ucdm.html">


### PR DESCRIPTION
Currently they are broken, they should not be 