### PR TITLE
Etienne/random ucdm 1p1 fixes

### DIFF
--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -186,7 +186,7 @@
                 <td>The foreign key to the Campus to which the Academic organization belongs.</td>
               </tr>
               <tr >
-                <td>SSI Internal Parent Academic organization ID</td>
+                <td>SIS Internal Parent Academic organization ID</td>
                 <td><code>ParentId</code></td>
                 <td><p><i>(optional)</i> The foreign key to the parent Academic organization of this Academic organization.</p></td>
               </tr>

--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -102,11 +102,6 @@
                 <td><p>The name of the Session. The value is typically intended to be humand-readable ("First 8-week") and, in concert with an Academic term name, fully communicate when a Course section is offered ("Fall 2018 First 8-week").</p></td>
               </tr>
               <tr >
-                <td>Session type</td>
-                <td><code>SessionType</code></td>
-                <td><p>The type of session, usually describing its length. This will take an option set, <a href="../tables/RefSessionType.html">RefSessionType</a>.</p></td>
-              </tr>
-              <tr >
                 <td>Instruction begin date</td>
                 <td><code>InstrBeginDate</code></td>
                 <td><p>The beginning of instruction for Course sections in the Session.</p></td>

--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -107,13 +107,13 @@
                 <td><p>The type of session, usually describing its length. This will take an option set, <a href="../tables/RefSessionType.html">RefSessionType</a>.</p></td>
               </tr>
               <tr >
-                <td>Instruction start date</td>
-                <td><code>StartDate</code></td>
+                <td>Instruction begin date</td>
+                <td><code>InstrBeginDate</code></td>
                 <td><p>The beginning of instruction for Course sections in the Session.</p></td>
               </tr>
               <tr >
                 <td>Instruction end date</td>
-                <td><code>EndDate</code></td>
+                <td><code>InstrEndDate</code></td>
                 <td><p>The end of instruction for Course sections in the Session.</p></td>
               </tr>
               <tr >

--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -268,6 +268,12 @@
             </thead>
             <tbody>
               <tr >
+                <td>Name</td>
+                <td><code>Name</code></td>
+                <td><font style="color: green; font-weight: bold">Add</font></td>
+                <td>The name of the Term. E.g., "Fall 2018.""</td>
+              </tr>
+              <tr >
                 <td>Session type</td>
                 <td><code>SessionType</code></td>
                 <td><font style="color: red; font-weight: bold">Remove</font></td>

--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -233,7 +233,7 @@
               </tr>
               <tr >
                 <td>SIS Internal Person ID</td>
-                <td><code>Person</code></td>
+                <td><code>PersonId</code></td>
                 <td><p>The foreign key to the Person to whom this Course grade belongs.</p></td>
               </tr>
               <tr >


### PR DESCRIPTION
Changes:

* Terms didn't have a name anymore (e.g., "Fall 2018") so I put one back in.
* Session start/end dates for instruction should have `Instr` prefix; they now do
* On Course Grade, `Person` should be `PersonId`
* Remove `SessionType` from Session

