### PR TITLE
Remove term dates

### DIFF
--- a/udp/ucdm/sis-loading-schema-v1p1.html
+++ b/udp/ucdm/sis-loading-schema-v1p1.html
@@ -281,6 +281,24 @@
                 <td>This value has been moved to the Session entity.</td>
               </tr>
               <tr >
+                <td>Begin date</td>
+                <td><code>TermBeginDate</code></td>
+                <td><font style="color: red; font-weight: bold">Remove</font></td>
+                <td>The "beginning" of a term can vary by business process.</td>
+              </tr>
+              <tr >
+                <td>End date</td>
+                <td><code>TermEndDate</code></td>
+                <td><font style="color: red; font-weight: bold">Remove</font></td>
+                <td>The "end" of a term can vary by business process.</td>
+              </tr>
+              <tr >
+                <td>Instruction start date</td>
+                <td><code>InstrBeginDate</code></td>
+                <td><font style="color: red; font-weight: bold">Remove</font></td>
+                <td>This value is replaced by a Session's instruction start date.</td>
+              </tr>
+              <tr >
                 <td>Instruction start date</td>
                 <td><code>InstrBeginDate</code></td>
                 <td><font style="color: red; font-weight: bold">Remove</font></td>


### PR DESCRIPTION
Remove `AcademicTerm.TermBeginDate` and `AcademicTerm.TermEndDate` in v1.1, since those elements are under-defined and too open to variation by business process, by institution, etc.