### PR TITLE
RefTermTypeId is not a column in OrganizationCalendarSession & CourseSection unused

### DIFF
--- a/udp/ucdm/queries-relational-store.html
+++ b/udp/ucdm/queries-relational-store.html
@@ -532,7 +532,6 @@
               -- Self-enrolled?
 
             FROM OrganizationPersonRole
-              INNER JOIN CourseSection on CourseSection.OrganizationId=OrganizationPersonRole.OrganizationPersonRoleId
               INNER JOIN Role on Role.RoleId=OrganizationPersonRole.RoleId
               INNER JOIN RoleStatus on RoleStatus.OrganizationPersonRoleId=OrganizationPersonRole.OrganizationPersonRoleId
               INNER JOIN RefRoleStatus on RefRoleStatus.RefRoleStatusId=RoleStatus.RefRoleStatusId

--- a/udp/ucdm/queries-relational-store.html
+++ b/udp/ucdm/queries-relational-store.html
@@ -423,7 +423,6 @@
           <pre style="padding-left: 0px; height: 100%; max-height: 100%; overflow-y: scroll">
             SELECT
               OrganizationCalendarSession.OrganizationCalendarSessionId as TermId,
-              RefTermType.Description as TermType,
               RefSessionType.Description as SessionType,
               OrganizationCalendarSession.SessionName as SessionName,
               OrganizationCalendarSession.BeginDate as TermBeginDate,
@@ -431,7 +430,6 @@
               OrganizationCalendarSession.FirstInstructionDate as InstrBeginDate,
               OrganizationCalendarSession.LastInstructionDate as InstrEndDate
             FROM OrganizationCalendarSession
-              LEFT JOIN RefTermType on RefTermType.RefTermTypeId=OrganizationCalendarSession.RefTermTypeId
               LEFT JOIN RefSessionType on RefSessionType.RefSessionTypeId=OrganizationCalendarSession.RefSessionTypeId
             WHERE OrganizationCalendarSession.OrganizationCalendarSessionId=2;
           </pre>
@@ -466,7 +464,8 @@
               LEFT JOIN OrganizationCalendarSession on OrganizationCalendarSession.OrganizationCalendarSessionId=PsCourse.OrganizationCalendarSessionId
               LEFT JOIN RefCourseCreditUnit on RefCourseCreditUnit.RefCourseCreditUnitId=Course.RefCourseCreditUnitId
               LEFT JOIN RefWorkflowState on RefWorkflowState.RefWorkflowStateId=Course.RefWorkflowStateId
-              LEFT JOIN RefTermType on RefTermType.RefTermTypeId=OrganizationCalendarSession.RefTermTypeId
+              LEFT JOIN OrganizationCalendar on OrganizationCalendar.OrganizationId=Course.OrganizationId 
+              LEFT JOIN RefTermType on RefTermType.RefTermTypeId=OrganizationCalendar.RefTermTypeId
               LEFT JOIN RefSessionType on RefSessionType.RefSessionTypeId=OrganizationCalendarSession.RefSessionTypeId
             Where Course.OrganizationId=1;
           </pre>


### PR DESCRIPTION
From what I can tell RefTermType is not a column in OrganizationCalendarSession, but it is in OrganizationCalendar. So these 2 queries seem like they need to be updated to work. It's possible the query for "Particular Academic Term" should be querying from OrganizationCalendar instead of OrganizationCalendarSession